### PR TITLE
Revert "CMake: Fix obsoleted required CMake version on Fedora 38"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(vf-gui-translation LANGUAGES CXX)
 set(VF_GUI_TRANSLATION_VERSION_MAJOR "1")


### PR DESCRIPTION
It caused unforeseeable results in zera-classes

This reverts commit bdafd78f519ff2f15dd6e976702ade863543a2f4.