### PR TITLE
Shrink size of png flags to our needs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(QTX "Qt${QT_MAJOR_VER}")
 
 find_package(${QTX} COMPONENTS Qml Quick LinguistTools CONFIG REQUIRED)
 find_package(Python REQUIRED)
+find_program(RSVG_CONVERT NAMES rsvg-convert NO_CACHE REQUIRED)
 if("${QT_MAJOR_VER}" STREQUAL "6")
     find_program(LRELEASE NAMES lrelease lrelease-qt6 NO_CACHE REQUIRED)
     find_program(LUPDATE NAMES lupdate lupdate-qt6 NO_CACHE REQUIRED)

--- a/flag_copy.sh
+++ b/flag_copy.sh
@@ -33,9 +33,30 @@ copy_flags()
     done
 }
 
+flag_width=256
+
+create_pngs_from_svgs()
+{
+    for file in `find "$DESTDIR_WITH_TRANSLATION" -name '*.qm'`; do
+        filename=`basename $file`
+        language=`echo $filename | sed -e 's:zera-gui_::' -e 's:.qm::'`
+        region=`echo $language | tr -d [:lower:] | tr -d '_'`
+        echo "Create png from svg $language / $region..."
+        svgfile="$FLAGS_SOURCE_DIR/svg/${region}.svg"
+        if [ ! -e "$svgfile" ]; then
+            echo "Could not find $svgfile" >&2
+            exit 1
+        fi
+        if ! rsvg-convert --width=${flag_width} --format=png $svgfile > "${DESTDIR_WITH_TRANSLATION}/flag_${language}.png"; then
+            echo "Could not create flag_${language}.png from $svgfile" >&2
+            exit 1
+        fi
+    done
+}
+
+
 format='svg'
 copy_flags
 
-format='png'
-copy_flags
+create_pngs_from_svgs
 


### PR DESCRIPTION
The files upstream created for us are 1024 pixels wide. To reduce memory footprint (factor 4*4=16) and reduce blitting cycles, tailor size of flags since we display small flags.

Important: Developer host needs librsvg2-tools as [1]

[1] https://github.com/ZeraGmbH/fedora-setup/commit/54e4d6bdb1a541ffc0e29278f76cb9ba9d916b03